### PR TITLE
Handle account selection on login

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -8,6 +8,11 @@
   "login_email": "you@example.com",
   "login_password": "your_password",
   "otp_secret_key": "OTP_SECRET",
+  "target_store": {
+    "store_name": "Example Store",
+    "merchant_id": "MERCHANT_ID",
+    "marketplace_id": "MARKETPLACE_ID"
+  },
   "max_concurrency": 35,
   "min_concurrency": 1,
   "initial_concurrency": 5,


### PR DESCRIPTION
## Summary
- handle account picker by selecting the target store
- show sample `target_store` config

## Testing
- `python -m py_compile inf.py`
- `flake8 inf.py` *(fails: E501 line too long, F401 imported but unused, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6866cd77b4648321ae91fdbe6f45f67c