### PR TITLE
Fix config generation when EMAIL_REPORT secret missing

### DIFF
--- a/.github/workflows/run-scraper.yml
+++ b/.github/workflows/run-scraper.yml
@@ -77,7 +77,7 @@ jobs:
             "login_password": "${{ secrets.LOGIN_PASSWORD }}",
             "otp_secret_key": "${{ secrets.OTP_SECRET_KEY }}",
             "inf_webhook_url": "${{ secrets.INF_WEBHOOK_URL }}",
-            "email_report": ${{ secrets.EMAIL_REPORT }},
+            "email_report": ${{ secrets.EMAIL_REPORT || 'false' }},
             "email_settings": {
               "smtp_server": "${{ secrets.SMTP_SERVER }}",
               "smtp_port": "${{ secrets.SMTP_PORT }}",


### PR DESCRIPTION
## Summary
- handle missing `EMAIL_REPORT` secret by defaulting to `false`

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile auth.py inf.py scraper.py notifications.py settings.py`
- `black --check .`

------
https://chatgpt.com/codex/tasks/task_e_6868ceb2886883218342a8f82f62cb2e