### PR TITLE
Add email thumbnail size setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,11 @@ This project collects "Item Not Found" (INF) metrics from Amazon Seller Central.
 
 1. **Python**: install Python 3.11.
 2. **Dependencies**: run `pip install -r requirements.txt`.
-3. **Configuration**: copy `config.example.json` to `config.json` and fill in the values. If `email_report` is enabled, configure the `email_settings` block with your SMTP server details.
+3. **Configuration**: copy `config.example.json` to `config.json` and fill in
+   the values. `thumbnail_size` controls the width of product images in
+   emails only (chat messages keep full-size images). If `email_report`
+   is enabled, configure the `email_settings` block with your SMTP server
+   details.
 4. **Run**: execute `python inf.py`. Use `--yesterday` to fetch the previous day's data.
 
 ## GitHub Actions

--- a/config.example.json
+++ b/config.example.json
@@ -20,6 +20,7 @@
   "marketplace_id": "YOUR_MARKETPLACE_ID",
   "target_url": "https://sellercentral.amazon.co.uk/snowdash?...",
   "debug": false,
+  "thumbnail_size": 150,
   "email_report": false,
   "email_settings": {
     "smtp_server": "smtp.example.com",

--- a/notifications.py
+++ b/notifications.py
@@ -18,6 +18,7 @@ from settings import (
     BATCH_SIZE,
     QR_CODE_SIZE,
     SMALL_IMAGE_SIZE,
+    EMAIL_THUMBNAIL_SIZE,
     LOCAL_TIMEZONE,
     JSON_LOG_FILE,
     EMAIL_REPORT,
@@ -172,7 +173,7 @@ async def email_inf_report(items: list[dict]) -> None:
 
     table_rows = "".join(
         f"<tr>"
-        f"<td><img src=\"{it['image_url']}\" alt=\"{it['product_name']}\" width=\"{SMALL_IMAGE_SIZE}\"></td>"
+        f"<td><img src=\"{it['image_url']}\" alt=\"{it['product_name']}\" width=\"{EMAIL_THUMBNAIL_SIZE}\"></td>"
         f"<td>{it['sku']}</td>"
         f"<td>{it['product_name']}</td>"
         f"<td>{it['inf_units']}</td>"

--- a/settings.py
+++ b/settings.py
@@ -10,7 +10,8 @@ import asyncio
 LOCAL_TIMEZONE = timezone("Europe/London")
 TABLE_POLL_DELAY = 1.0  # seconds to wait after table actions
 BATCH_SIZE = 30  # max items per webhook message
-SMALL_IMAGE_SIZE = 300  # px for product thumbnails
+SMALL_IMAGE_SIZE = 300  # px for product thumbnails used in chat messages
+EMAIL_THUMBNAIL_SIZE = 150  # px for product images in email
 QR_CODE_SIZE = 80  # px for QR codes
 
 
@@ -40,6 +41,8 @@ try:
 except FileNotFoundError:
     app_logger.critical("config.json not found. Please create it before running.")
     exit(1)
+
+EMAIL_THUMBNAIL_SIZE = config.get("thumbnail_size", EMAIL_THUMBNAIL_SIZE)
 
 DEBUG_MODE = config.get("debug", False)
 LOGIN_URL = config["login_url"]


### PR DESCRIPTION
## Summary
- keep 300px resolution for chat message images
- use new `EMAIL_THUMBNAIL_SIZE` (default 150px) for email reports
- document that `thumbnail_size` only affects email images

## Testing
- `black .`
- `python -m py_compile auth.py inf.py scraper.py notifications.py settings.py`
- `black --check .`


------
https://chatgpt.com/codex/tasks/task_e_6868d89dd2648321adbebbaff0c2578f