### PR TITLE
Improve stability of yesterday filter

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -7,6 +7,7 @@ from settings import (
     WAIT_TIMEOUT,
     TABLE_POLL_DELAY,
     SMALL_IMAGE_SIZE,
+    DATE_FILTER_DELAY,
     app_logger,
 )
 
@@ -62,6 +63,7 @@ async def scrape_inf_data(
             app_logger.info("Applying 'Yesterday' filter")
             link = page.get_by_role("link", name="Yesterday")
             await wait_for_table_change(page, table_sel, lambda: link.click())
+            await asyncio.sleep(DATE_FILTER_DELAY)
 
         try:
             await expect(page.locator(f"{table_sel} tr").first).to_be_visible(

--- a/settings.py
+++ b/settings.py
@@ -9,6 +9,7 @@ import asyncio
 # Basic constants
 LOCAL_TIMEZONE = timezone("Europe/London")
 TABLE_POLL_DELAY = 1.0  # seconds to wait after table actions
+DATE_FILTER_DELAY = 2.0  # extra wait after selecting the date filter
 BATCH_SIZE = 30  # max items per webhook message
 SMALL_IMAGE_SIZE = 300  # px for product thumbnails used in chat messages
 EMAIL_THUMBNAIL_SIZE = 80  # px for product images in email


### PR DESCRIPTION
## Summary
- add new `DATE_FILTER_DELAY` setting for date pickers
- wait for that delay after selecting Yesterday

## Testing
- `pip install black`
- `black .`
- `python -m py_compile auth.py inf.py scraper.py notifications.py settings.py`
- `black --check .`


------
https://chatgpt.com/codex/tasks/task_e_6868e5c0941c8321ba034cac7a1a3641