### PR TITLE
Fix Supabase config error in actions

### DIFF
--- a/.github/workflows/run-scraper.yml
+++ b/.github/workflows/run-scraper.yml
@@ -79,6 +79,8 @@ jobs:
             "inf_webhook_url": "${{ secrets.INF_WEBHOOK_URL }}",
             "email_report": false,
             "enable_supabase_upload": true,
+            "supabase_url": "${{ secrets.SUPABASE_URL }}",
+            "supabase_service_key": "${{ secrets.SUPABASE_SERVICE_KEY }}",
             "target_store": {
               "store_name": "${{ secrets.TARGET_STORE_NAME }}",
               "merchant_id": "${{ secrets.TARGET_MERCHANT_ID }}",

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Configure the following repository secrets used by the workflows:
 - `LOGIN_PASSWORD`
 - `OTP_SECRET_KEY`
 - `INF_WEBHOOK_URL` (used by `run-scraper.yml`)
+- `SUPABASE_URL`
+- `SUPABASE_SERVICE_KEY`
 - `TARGET_STORE_NAME`
 - `TARGET_MERCHANT_ID`
 - `TARGET_MARKETPLACE_ID`


### PR DESCRIPTION
## Summary
- include SUPABASE secrets in run-scraper workflow
- document Supabase secrets in README

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile auth.py inf.py scraper.py notifications.py settings.py`
- `black --check .`


------
https://chatgpt.com/codex/tasks/task_e_6868fdeb3054832187e765a6138501a2