### PR TITLE
Fix Supabase query when investigation doesn't exist

### DIFF
--- a/database.py
+++ b/database.py
@@ -54,7 +54,7 @@ async def create_investigation_from_scrape(items: list[dict]) -> None:
                 supabase_client.table("investigations")
                 .select("id")
                 .eq("name", investigation_name)
-                .single()
+                .maybe_single()
                 .execute()
             )
             if existing.data:


### PR DESCRIPTION
## Summary
- handle zero results when looking up investigations

## Testing
- `black . --check`
- `python -m py_compile auth.py inf.py scraper.py notifications.py settings.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bbb2c383c83218b96b41ff3e605c2