### PR TITLE
Adjust email workflow behavior

### DIFF
--- a/.github/workflows/email-report.yml
+++ b/.github/workflows/email-report.yml
@@ -78,7 +78,7 @@ jobs:
             "otp_secret_key": "${{ secrets.OTP_SECRET_KEY }}",
             "inf_webhook_url": "",
             "email_report": true,
-            "enable_supabase_upload": true,
+            "enable_supabase_upload": false,
             "supabase_url": "${{ secrets.SUPABASE_URL }}",
             "supabase_service_key": "${{ secrets.SUPABASE_SERVICE_KEY }}",
             "email_settings": {

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ This project collects "Item Not Found" (INF) metrics from Amazon Seller Central.
 The repository contains two GitHub workflows:
 
 - `.github/workflows/run-scraper.yml` posts INF items to the chat webhook on a schedule and never emails the report.
-- `.github/workflows/email-report.yml` sends the daily email report only.
+- `.github/workflows/email-report.yml` sends the daily email report only. It
+  always scrapes **yesterday's** data and skips Supabase updates.
 
 Configure the following repository secrets used by the workflows:
 

--- a/inf.py
+++ b/inf.py
@@ -58,11 +58,12 @@ async def main(args):
 
     storage = json.load(open(STORAGE_STATE))
     app_logger.info("Beginning data scrape")
+    fetch_yesterday = args.yesterday or EMAIL_REPORT
     data = await scrape_with_retries(
         browser,
         TARGET_STORE,
         storage,
-        fetch_yesterday=args.yesterday,
+        fetch_yesterday=fetch_yesterday,
         attempts=SCRAPE_RETRIES,
     )
 
@@ -73,11 +74,13 @@ async def main(args):
     else:
         app_logger.info(f"Retrieved {len(data)} INF items; processing...")
 
-        if ENABLE_SUPABASE_UPLOAD:
+        if ENABLE_SUPABASE_UPLOAD and not EMAIL_REPORT:
             app_logger.info("Supabase upload is enabled. Creating investigation...")
             await create_investigation_from_scrape(data)
         else:
-            app_logger.info("Supabase upload is disabled. Skipping database update.")
+            app_logger.info(
+                "Supabase upload disabled or email mode active. Skipping database update."
+            )
 
         # Run existing logging and notification steps
         await log_inf_results(data)


### PR DESCRIPTION
## Summary
- ensure email workflow always fetches yesterday's data and skips Supabase upload
- enforce yesterday scraping and disable Supabase in email mode
- document email workflow behavior

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile auth.py inf.py scraper.py notifications.py settings.py`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686ea576ef348321afeba001c8634ebb