### PR TITLE
Fix missing EMAIL_REPORT import

### DIFF
--- a/inf.py
+++ b/inf.py
@@ -17,6 +17,7 @@ from settings import (
     STORAGE_STATE,
     INVENTORY_URL,
     ENABLE_SUPABASE_UPLOAD,
+    EMAIL_REPORT,
     LOGIN_RETRIES,
     SCRAPE_RETRIES,
 )


### PR DESCRIPTION
## Summary
- import `EMAIL_REPORT` in `inf.py`

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile auth.py inf.py scraper.py notifications.py settings.py`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687001d6c5348321b15eb9d88e9b51b3