### PR TITLE
Handle promo locations in INF chat report

### DIFF
--- a/notifications.py
+++ b/notifications.py
@@ -63,10 +63,7 @@ async def post_inf_to_chat(items: list[dict]) -> None:
     if ENABLE_STOCK_LOOKUP:
         zero_stock = [it for it in items if it.get("stock_on_hand") == 0]
         extra_locs = [
-            it
-            for it in items
-            if it not in zero_stock
-            and (it.get("std_location") or it.get("promo_location"))
+            it for it in items if it not in zero_stock and it.get("promo_location")
         ]
         others = [it for it in items if it not in zero_stock and it not in extra_locs]
         categories = [


### PR DESCRIPTION
## Summary
- treat items as having additional locations only when a promotional location is present

## Testing
- `python -m py_compile auth.py inf.py scraper.py notifications.py settings.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891c23043488321aece77be36ebcacf