### PR TITLE
Expose aisle numbers and sort chat posts

### DIFF
--- a/database.py
+++ b/database.py
@@ -88,6 +88,7 @@ async def create_investigation_from_scrape(items: list[dict]) -> None:
                 "stock_last_updated": item.get("stock_last_updated"),
                 "std_location": item.get("std_location"),
                 "promo_location": item.get("promo_location"),
+                "aisle_number": item.get("aisle_number"),
             }
             for item in items
         ]

--- a/notifications.py
+++ b/notifications.py
@@ -57,6 +57,14 @@ async def post_inf_to_chat(items: list[dict]) -> None:
         app_logger.info("No items to post; skipping chat post.")
         return
 
+    def _aisle_sort_key(it: dict) -> int:
+        try:
+            return int(it.get("aisle_number"))
+        except (TypeError, ValueError):
+            return float("inf")
+
+    items = sorted(items, key=_aisle_sort_key)
+
     ts = datetime.now(LOCAL_TIMEZONE).strftime("%A %d %B, %H:%M")
     store = TARGET_STORE["store_name"]
 
@@ -77,6 +85,8 @@ async def post_inf_to_chat(items: list[dict]) -> None:
     for cat_label, cat_items in categories:
         if not cat_items:
             continue
+
+        cat_items.sort(key=_aisle_sort_key)
 
         if SINGLE_CARD:
             batches = [cat_items[:BATCH_SIZE]]

--- a/stock_checker.py
+++ b/stock_checker.py
@@ -71,13 +71,14 @@ def simplify_locations(lst: list[dict]) -> str:
     return "; ".join(nice_loc(l) for l in lst) if lst else ""
 
 
-def extract_location_bits(pi: dict | None) -> tuple[str, str]:
+def extract_location_bits(pi: dict | None) -> tuple[str, str, str | None]:
     if not pi:
-        return "", ""
+        return "", "", None
     space = pi.get("space", {})
     std_lst = space.get("standardSpace", {}).get("locations", [])
     promo_lst = space.get("promotionalSpace", {}).get("locations", [])
-    return simplify_locations(std_lst), simplify_locations(promo_lst)
+    aisle_number = std_lst[0].get("aisle") if std_lst else None
+    return simplify_locations(std_lst), simplify_locations(promo_lst), aisle_number
 
 
 def _fetch_morrisons_data_for_sku(sku: str) -> dict[str, Any]:
@@ -126,9 +127,10 @@ def _fetch_morrisons_data_for_sku(sku: str) -> dict[str, Any]:
         pi_url = f"{BASE_LOCN}/{MORRISONS_LOCATION_ID}/items/{pi_sku}?apikey={MORRISONS_API_KEY}"
         pi_data = _fetch_json(pi_url, MORRISONS_BEARER_TOKEN)
         if pi_data:
-            std_loc, promo_loc = extract_location_bits(pi_data)
+            std_loc, promo_loc, aisle_number = extract_location_bits(pi_data)
             results["std_location"] = std_loc
             results["promo_location"] = promo_loc
+            results["aisle_number"] = aisle_number
             app_logger.info(f"Found locations for PI SKU {pi_sku}")
 
         return results


### PR DESCRIPTION
## Summary
- Capture aisle numbers from Morrisons location data and include them in enriched items.
- Store each item's aisle number when creating investigations.
- Sort INF notification batches by aisle number for orderly chat posts.

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile auth.py inf.py scraper.py notifications.py settings.py stock_checker.py database.py`
- `black --check database.py notifications.py stock_checker.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893915db4f08321931a09fce616e299