### PR TITLE
Fetch Morrisons bearer token from public gist

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ This project collects "Item Not Found" (INF) metrics from Amazon Seller Central.
    the values. `thumbnail_size` controls the width of product images in
    emails only (chat messages keep full-size images). If `email_report`
    is enabled, configure the `email_settings` block with your SMTP server
-   details.
+   details. If `enable_stock_lookup` is set, the Morrisons bearer token is
+   fetched automatically from a public gist and should not be stored in
+   `config.json`.
 4. **Run**: execute `python inf.py`. Use `--yesterday` to fetch the previous day's data.
 
 ## GitHub Actions


### PR DESCRIPTION
## Summary
- Retrieve Morrisons bearer token from a published gist and fall back to config when unavailable
- Document automatic bearer token retrieval in setup instructions

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile auth.py inf.py scraper.py notifications.py settings.py`
- `black --check settings.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c15e0c3f888321b6a615c5c47c0197