### PR TITLE
Filter INF duplicates in daily runs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,31 @@
+import json
+from pathlib import Path
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_CONFIG_PATH = _REPO_ROOT / "config.json"
+_CONFIG_CREATED = False
+
+if not _CONFIG_PATH.exists():
+    _CONFIG = {
+        "login_url": "https://example.com/login",
+        "target_store": {
+            "store_name": "Test Store",
+            "merchant_id": "TEST",
+            "marketplace_id": "TEST",
+            "morrisons_location_id": "TEST",
+        },
+        "inf_webhook_url": "",
+        "single_card": False,
+        "enable_stock_lookup": False,
+        "enable_supabase_upload": False,
+        "email_report": False,
+        "email_settings": {},
+    }
+    _CONFIG_PATH.write_text(json.dumps(_CONFIG))
+    _CONFIG_CREATED = True
+
+
+def pytest_sessionfinish(session, exitstatus):  # type: ignore[override]
+    if _CONFIG_CREATED:
+        _CONFIG_PATH.unlink(missing_ok=True)

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,0 +1,52 @@
+import asyncio
+import json
+from datetime import datetime, timedelta
+
+import pytest
+
+import notifications
+
+
+@pytest.fixture
+def log_file(tmp_path, monkeypatch):
+    path = tmp_path / "inf_items.jsonl"
+    monkeypatch.setattr(notifications, "JSON_LOG_FILE", str(path))
+    return path
+
+
+def test_filter_items_posted_today_without_history(log_file):
+    items = [{"sku": "SKU-1"}, {"sku": "SKU-2"}]
+
+    filtered = asyncio.run(notifications.filter_items_posted_today(items))
+
+    assert filtered == items
+
+
+def test_filter_items_posted_today_ignores_previous_days(log_file):
+    yesterday = datetime.now(notifications.LOCAL_TIMEZONE) - timedelta(days=1)
+    entry = {
+        "timestamp": yesterday.strftime("%Y-%m-%d %H:%M:%S"),
+        "inf_items": [{"sku": "SKU-1"}],
+    }
+    log_file.write_text(json.dumps(entry) + "\n")
+
+    items = [{"sku": "SKU-1"}, {"sku": "SKU-2"}]
+
+    filtered = asyncio.run(notifications.filter_items_posted_today(items))
+
+    assert filtered == items
+
+
+def test_filter_items_posted_today_excludes_current_day_duplicates(log_file):
+    today = datetime.now(notifications.LOCAL_TIMEZONE)
+    entry = {
+        "timestamp": today.strftime("%Y-%m-%d %H:%M:%S"),
+        "inf_items": [{"sku": "SKU-1"}],
+    }
+    log_file.write_text(json.dumps(entry) + "\n")
+
+    items = [{"sku": "SKU-1"}, {"sku": "SKU-2"}, {"sku": "SKU-3"}]
+
+    filtered = asyncio.run(notifications.filter_items_posted_today(items))
+
+    assert [item["sku"] for item in filtered] == ["SKU-2", "SKU-3"]


### PR DESCRIPTION
## Summary
- add filtering logic that reads the JSON log and removes INF items already posted earlier in the day
- integrate the daily duplicate check into the main run flow and add tests covering the new behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7cee932648321ab015dff247ac909