### PR TITLE
Sync log history from GitHub artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,28 @@ The email report workflow also requires these SMTP secrets:
 
 The workflow builds `config.json` from these secrets and runs `python inf.py`. Artifacts such as log files and scraped data are uploaded for inspection.
 
+### Preventing duplicate chat messages in Actions
+
+`filter_items_posted_today` normally reads from `output/inf_items.jsonl` to avoid
+sending duplicate chat messages in the same day. GitHub Actions runners start
+fresh on every run, so the log file can be empty. Enable the optional
+`github_artifact` block in `config.json` to pull the most recent log history from
+an artifact before filtering:
+
+```json
+"github_artifact": {
+  "enable_log_sync": true,
+  "artifact_name": "inf-items-history",
+  "repository": "owner/repo",
+  "token_env_var": "GITHUB_TOKEN"
+}
+```
+
+Ensure your workflow uploads `output/inf_items.jsonl` with
+`actions/upload-artifact` under the matching name after each run. When the
+next workflow starts, the scraper will download that artifact using the
+provided token and reuse the logged SKUs for duplicate suppression.
+
 `run-scraper.yml` disables emailing, while `email-report.yml` omits the chat webhook.
 
 

--- a/artifact_utils.py
+++ b/artifact_utils.py
@@ -1,0 +1,171 @@
+"""Utilities for syncing log history from GitHub Actions artifacts."""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import os
+import zipfile
+from typing import Optional
+
+import aiohttp
+
+from settings import (
+    ENABLE_ARTIFACT_LOG_SYNC,
+    GITHUB_ARTIFACT_NAME,
+    GITHUB_ARTIFACT_REPOSITORY,
+    GITHUB_ARTIFACT_TOKEN,
+    JSON_LOG_FILE,
+    app_logger,
+)
+
+
+_artifact_lock = asyncio.Lock()
+_artifact_checked = False
+
+
+async def ensure_log_history_from_artifact() -> None:
+    """Download the latest log artifact if local history is missing."""
+
+    global _artifact_checked
+
+    if _artifact_checked:
+        return
+
+    if not ENABLE_ARTIFACT_LOG_SYNC:
+        _artifact_checked = True
+        return
+
+    if JSON_LOG_FILE and os.path.exists(JSON_LOG_FILE):
+        if os.path.getsize(JSON_LOG_FILE) > 0:
+            _artifact_checked = True
+            return
+
+    async with _artifact_lock:
+        if _artifact_checked:
+            return
+
+        try:
+            await _download_log_history()
+        finally:
+            _artifact_checked = True
+
+
+async def _download_log_history() -> None:
+    if not GITHUB_ARTIFACT_NAME:
+        app_logger.warning(
+            "Artifact log sync enabled but no artifact name configured; skipping."
+        )
+        return
+
+    if not GITHUB_ARTIFACT_REPOSITORY:
+        app_logger.warning(
+            "Artifact log sync enabled but repository is unknown; skipping."
+        )
+        return
+
+    if not GITHUB_ARTIFACT_TOKEN:
+        app_logger.warning(
+            "Artifact log sync enabled but no GitHub token available; skipping."
+        )
+        return
+
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {GITHUB_ARTIFACT_TOKEN}",
+        "User-Agent": "inf-artifact-sync",
+    }
+
+    artifacts_url = (
+        f"https://api.github.com/repos/{GITHUB_ARTIFACT_REPOSITORY}/actions/artifacts"
+    )
+
+    async with aiohttp.ClientSession(headers=headers) as session:
+        artifact = await _find_latest_artifact(session, artifacts_url)
+
+        if not artifact:
+            app_logger.info(
+                "No matching artifact named '%s' was found for log sync.",
+                GITHUB_ARTIFACT_NAME,
+            )
+            return
+
+        await _save_artifact_log(session, artifact["archive_download_url"])
+
+
+async def _find_latest_artifact(
+    session: aiohttp.ClientSession, url: str
+) -> Optional[dict]:
+    page = 1
+    per_page = 100
+
+    while True:
+        params = {"per_page": per_page, "page": page}
+        async with session.get(url, params=params) as response:
+            if response.status != 200:
+                text = await response.text()
+                app_logger.error(
+                    "Failed to list artifacts (status %s): %s",
+                    response.status,
+                    text,
+                )
+                return None
+
+            payload = await response.json()
+            artifacts = payload.get("artifacts", [])
+
+            for artifact in artifacts:
+                if artifact.get("name") != GITHUB_ARTIFACT_NAME:
+                    continue
+                if artifact.get("expired"):
+                    continue
+                return artifact
+
+            if len(artifacts) < per_page:
+                return None
+
+            page += 1
+
+
+async def _save_artifact_log(session: aiohttp.ClientSession, download_url: str) -> None:
+    async with session.get(download_url) as response:
+        if response.status != 200:
+            text = await response.text()
+            app_logger.error(
+                "Failed to download artifact archive (status %s): %s",
+                response.status,
+                text,
+            )
+            return
+
+        content = await response.read()
+
+    if not content:
+        app_logger.warning("Artifact archive was empty; skipping log sync.")
+        return
+
+    log_bytes = _extract_log_from_zip(content)
+    if log_bytes is None:
+        app_logger.warning(
+            "Artifact archive did not contain an 'inf_items.jsonl' file."
+        )
+        return
+
+    os.makedirs(os.path.dirname(JSON_LOG_FILE), exist_ok=True)
+
+    with open(JSON_LOG_FILE, "wb") as destination:
+        destination.write(log_bytes)
+
+    app_logger.info("Downloaded log history from artifact '%s'.", GITHUB_ARTIFACT_NAME)
+
+
+def _extract_log_from_zip(content: bytes) -> Optional[bytes]:
+    buffer = io.BytesIO(content)
+
+    with zipfile.ZipFile(buffer) as archive:
+        for name in archive.namelist():
+            if name.endswith("inf_items.jsonl"):
+                with archive.open(name) as member:
+                    return member.read()
+
+    return None

--- a/config.example.json
+++ b/config.example.json
@@ -33,6 +33,12 @@
     "from_addr": "inf-report@example.com",
     "to_addr": "recipient@example.com"
   },
+  "github_artifact": {
+    "enable_log_sync": false,
+    "artifact_name": "inf-items-history",
+    "repository": "owner/repo",
+    "token_env_var": "GITHUB_TOKEN"
+  },
   "schedule_times": ["10:00", "16:00", "19:00"],
   "auto_concurrency": {
     "enabled": true,

--- a/notifications.py
+++ b/notifications.py
@@ -1,8 +1,8 @@
+import asyncio
 import json
 import ssl
 import urllib.parse
 from datetime import datetime
-import asyncio
 import smtplib
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
@@ -11,6 +11,7 @@ import aiohttp
 import aiofiles
 import certifi
 
+from artifact_utils import ensure_log_history_from_artifact
 from settings import (
     INF_WEBHOOK,
     TARGET_STORE,
@@ -54,6 +55,8 @@ async def filter_items_posted_today(items: list[dict]) -> list[dict]:
 
     if not items:
         return []
+
+    await ensure_log_history_from_artifact()
 
     today = datetime.now(LOCAL_TIMEZONE).date()
     posted_skus: set[str] = set()

--- a/settings.py
+++ b/settings.py
@@ -126,6 +126,17 @@ os.makedirs(OUTPUT_DIR, exist_ok=True)
 JSON_LOG_FILE = os.path.join(OUTPUT_DIR, "inf_items.jsonl")
 STORAGE_STATE = "state.json"
 
+# GitHub artifact settings
+GITHUB_ARTIFACT_SETTINGS = config.get("github_artifact", {})
+ENABLE_ARTIFACT_LOG_SYNC = GITHUB_ARTIFACT_SETTINGS.get("enable_log_sync", False)
+GITHUB_ARTIFACT_NAME = GITHUB_ARTIFACT_SETTINGS.get("artifact_name")
+GITHUB_ARTIFACT_REPOSITORY = GITHUB_ARTIFACT_SETTINGS.get("repository") or os.getenv(
+    "GITHUB_REPOSITORY"
+)
+GITHUB_ARTIFACT_TOKEN = os.getenv(
+    GITHUB_ARTIFACT_SETTINGS.get("token_env_var", "GITHUB_TOKEN")
+)
+
 PAGE_TIMEOUT = 120_000
 ACTION_TIMEOUT = 60_000
 WAIT_TIMEOUT = 60_000

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -22,6 +22,22 @@ def test_filter_items_posted_today_without_history(log_file):
     assert filtered == items
 
 
+def test_filter_items_posted_today_syncs_artifact(monkeypatch, log_file):
+    called = False
+
+    async def fake_sync():
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(notifications, "ensure_log_history_from_artifact", fake_sync)
+
+    items = [{"sku": "SKU-1"}]
+
+    asyncio.run(notifications.filter_items_posted_today(items))
+
+    assert called is True
+
+
 def test_filter_items_posted_today_ignores_previous_days(log_file):
     yesterday = datetime.now(notifications.LOCAL_TIMEZONE) - timedelta(days=1)
     entry = {


### PR DESCRIPTION
## Summary
- add an async utility that downloads the most recent INF log from GitHub Actions artifacts when local history is missing
- hook the duplicate filter into the artifact sync, expose configuration in settings, and document usage in the README and sample config
- extend notification tests to ensure the artifact sync is triggered before filtering

## Testing
- black .
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d7d2df786483218d03e3cd6d1d3cd6