### PR TITLE
Use consistent artifact name for log history

### DIFF
--- a/.github/workflows/email-report.yml
+++ b/.github/workflows/email-report.yml
@@ -107,7 +107,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: inf-email-output-${{ github.run_id }}
+          name: inf-items-history
           path: |
             output/
             inf_app.log

--- a/.github/workflows/run-scraper.yml
+++ b/.github/workflows/run-scraper.yml
@@ -99,7 +99,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: inf-scraper-output-${{ github.run_id }}
+          name: inf-items-history
           path: |
             output/
             inf_app.log


### PR DESCRIPTION
## Summary
- update both GitHub workflows to upload the log artifact under the consistent `inf-items-history` name expected by the scraper

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d83fffa5188321bcdb1a2a50173002