### PR TITLE
Enable artifact-backed log history syncing

### DIFF
--- a/.github/workflows/run-scraper.yml
+++ b/.github/workflows/run-scraper.yml
@@ -89,6 +89,11 @@ jobs:
               "merchant_id": "${{ secrets.TARGET_MERCHANT_ID }}",
               "marketplace_id": "${{ secrets.TARGET_MARKETPLACE_ID }}",
               "morrisons_location_id": "${{ secrets.TARGET_MORRISONS_LOCATION_ID }}"
+            },
+            "github_artifact": {
+              "enable_log_sync": true,
+              "artifact_name": "inf-items-history",
+              "token_env_var": "GITHUB_TOKEN"
             }
           }' > config.json
 


### PR DESCRIPTION
## Summary
- add the github_artifact configuration block to the generated config.json so log history can sync from the inf-items-history artifact

## Testing
- python -m py_compile auth.py inf.py scraper.py notifications.py settings.py

------
https://chatgpt.com/codex/tasks/task_e_68da819cc3b48321b0cc2482be3ea5c5