### PR TITLE
Allow artifact token fallback from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,14 +60,17 @@ an artifact before filtering:
   "enable_log_sync": true,
   "artifact_name": "inf-items-history",
   "repository": "owner/repo",
-  "token_env_var": "GITHUB_TOKEN"
+  "token_env_var": "GITHUB_TOKEN",
+  "token": "ghp_your_token_here"
 }
 ```
 
 Ensure your workflow uploads `output/inf_items.jsonl` with
 `actions/upload-artifact` under the matching name after each run. When the
 next workflow starts, the scraper will download that artifact using the
-provided token and reuse the logged SKUs for duplicate suppression.
+provided token and reuse the logged SKUs for duplicate suppression. The token
+can be supplied either via the configured environment variable or directly in
+`config.json` for local runs.
 
 `run-scraper.yml` disables emailing, while `email-report.yml` omits the chat webhook.
 

--- a/artifact_utils.py
+++ b/artifact_utils.py
@@ -15,6 +15,7 @@ from settings import (
     GITHUB_ARTIFACT_NAME,
     GITHUB_ARTIFACT_REPOSITORY,
     GITHUB_ARTIFACT_TOKEN,
+    GITHUB_ARTIFACT_TOKEN_ENV_VAR,
     JSON_LOG_FILE,
     app_logger,
 )
@@ -66,7 +67,9 @@ async def _download_log_history() -> None:
 
     if not GITHUB_ARTIFACT_TOKEN:
         app_logger.warning(
-            "Artifact log sync enabled but no GitHub token available; skipping."
+            "Artifact log sync enabled but no GitHub token was available. Set %s "
+            "or provide 'github_artifact.token' in config.json to enable log sync.",
+            GITHUB_ARTIFACT_TOKEN_ENV_VAR,
         )
         return
 

--- a/config.example.json
+++ b/config.example.json
@@ -37,7 +37,8 @@
     "enable_log_sync": false,
     "artifact_name": "inf-items-history",
     "repository": "owner/repo",
-    "token_env_var": "GITHUB_TOKEN"
+    "token_env_var": "GITHUB_TOKEN",
+    "token": "ghp_your_token_here"
   },
   "schedule_times": ["10:00", "16:00", "19:00"],
   "auto_concurrency": {

--- a/settings.py
+++ b/settings.py
@@ -133,9 +133,22 @@ GITHUB_ARTIFACT_NAME = GITHUB_ARTIFACT_SETTINGS.get("artifact_name")
 GITHUB_ARTIFACT_REPOSITORY = GITHUB_ARTIFACT_SETTINGS.get("repository") or os.getenv(
     "GITHUB_REPOSITORY"
 )
-GITHUB_ARTIFACT_TOKEN = os.getenv(
-    GITHUB_ARTIFACT_SETTINGS.get("token_env_var", "GITHUB_TOKEN")
+GITHUB_ARTIFACT_TOKEN_ENV_VAR = GITHUB_ARTIFACT_SETTINGS.get(
+    "token_env_var", "GITHUB_TOKEN"
 )
+GITHUB_ARTIFACT_TOKEN = os.getenv(GITHUB_ARTIFACT_TOKEN_ENV_VAR)
+
+if not GITHUB_ARTIFACT_TOKEN:
+    config_token = GITHUB_ARTIFACT_SETTINGS.get("token")
+    if config_token:
+        GITHUB_ARTIFACT_TOKEN = config_token
+    elif ENABLE_ARTIFACT_LOG_SYNC:
+        app_logger.warning(
+            "Artifact log sync is enabled but %s was not set and no token was "
+            "provided in config; log history will not be downloaded.",
+            GITHUB_ARTIFACT_TOKEN_ENV_VAR,
+        )
+        ENABLE_ARTIFACT_LOG_SYNC = False
 
 PAGE_TIMEOUT = 120_000
 ACTION_TIMEOUT = 60_000


### PR DESCRIPTION
## Summary
- allow artifact log sync to fall back to a token provided in config.json when the expected environment variable is unset
- disable log sync automatically when no token is available so the warning is emitted only once
- document the optional token field in the README and example configuration

## Testing
- python -m py_compile auth.py inf.py scraper.py notifications.py settings.py

------
https://chatgpt.com/codex/tasks/task_e_68da86d081e08321a84b030e7f9ef451