### PR TITLE
Grant workflow token permissions for scheduled runs

### DIFF
--- a/.github/workflows/run-scraper.yml
+++ b/.github/workflows/run-scraper.yml
@@ -1,5 +1,9 @@
 name: Run Amazon INF Scraper
 
+permissions:
+  contents: read
+  actions: write
+
 on:
   workflow_dispatch:
   schedule:
@@ -43,6 +47,8 @@ jobs:
     if: needs.check-time.outputs.run_job == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
 
     steps:
       - name: 1. Check out repository
@@ -98,8 +104,6 @@ jobs:
           }' > config.json
 
       - name: 7. Run the INF scraper
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python inf.py
 
       - name: 8. Upload artifacts


### PR DESCRIPTION
## Summary
- grant the scraper workflow the Actions write permission so scheduled runs can use the GITHUB_TOKEN
- set the workflow job-level GITHUB_TOKEN environment variable and drop the redundant step-level configuration

## Testing
- python -m py_compile auth.py inf.py scraper.py notifications.py settings.py

------
https://chatgpt.com/codex/tasks/task_e_68da8ac8350483219279cfa1eea8c519